### PR TITLE
[UPDATE] 이용 불가능한 매장의 CCTV에 접근을 막는 로직 추가

### DIFF
--- a/src/main/java/com/ssg/usms/business/cctv/controller/CctvController.java
+++ b/src/main/java/com/ssg/usms/business/cctv/controller/CctvController.java
@@ -1,10 +1,11 @@
 package com.ssg.usms.business.cctv.controller;
 
-import com.ssg.usms.business.security.login.UsmsUserDetails;
 import com.ssg.usms.business.cctv.dto.CctvDto;
 import com.ssg.usms.business.cctv.dto.HttpRequestCreatingCctvDto;
 import com.ssg.usms.business.cctv.dto.HttpRequestUpdatingCctvDto;
 import com.ssg.usms.business.cctv.service.CctvService;
+import com.ssg.usms.business.security.login.UsmsUserDetails;
+import com.ssg.usms.business.store.exception.UnavailableStoreException;
 import com.ssg.usms.business.store.service.StoreService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -40,6 +41,9 @@ public class CctvController {
         // 검증
         userId = ((UsmsUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getId();
         storeService.validateOwnedStore(storeId, userId);
+        if(!storeService.isAvailable(userId)) {
+            throw new UnavailableStoreException();
+        }
 
         // 비지니스 로직
         cctvService.createCctv(storeId, requestBody.getName());
@@ -64,6 +68,9 @@ public class CctvController {
             userId = ((UsmsUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getId();
             storeService.validateOwnedStore(storeId, userId);
             cctvService.validateOwnedCctv(storeId, cctvId);
+            if(!storeService.isAvailable(userId)) {
+                throw new UnavailableStoreException();
+            }
         }
 
         // 비지니스 로직
@@ -93,6 +100,9 @@ public class CctvController {
         if (!authorities.get(0).getAuthority().equals(ROLE_ADMIN.name())) {
             userId = ((UsmsUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getId();
             storeService.validateOwnedStore(storeId, userId);
+            if(!storeService.isAvailable(userId)) {
+                throw new UnavailableStoreException();
+            }
         }
 
         // 비지니스 로직
@@ -109,6 +119,9 @@ public class CctvController {
         userId = ((UsmsUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getId();
         storeService.validateOwnedStore(storeId, userId);
         cctvService.validateOwnedCctv(storeId, cctvId);
+        if(!storeService.isAvailable(userId)) {
+            throw new UnavailableStoreException();
+        }
 
         // 비지니스 로직
         cctvService.changeCctvName(cctvId, requestBody.getName());
@@ -125,6 +138,9 @@ public class CctvController {
         userId = ((UsmsUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getId();
         storeService.validateOwnedStore(storeId, userId);
         cctvService.validateOwnedCctv(storeId, cctvId);
+        if(!storeService.isAvailable(userId)) {
+            throw new UnavailableStoreException();
+        }
 
         // 비지니스 로직
         cctvService.deleteCctv(cctvId);

--- a/src/main/java/com/ssg/usms/business/cctv/handler/CctvExceptionHandler.java
+++ b/src/main/java/com/ssg/usms/business/cctv/handler/CctvExceptionHandler.java
@@ -6,6 +6,7 @@ import com.ssg.usms.business.cctv.exception.NotOwnedCctvException;
 import com.ssg.usms.business.error.ErrorResponseDto;
 import com.ssg.usms.business.store.exception.NotExistingStoreException;
 import com.ssg.usms.business.store.exception.NotOwnedStoreException;
+import com.ssg.usms.business.store.exception.UnavailableStoreException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -93,6 +94,17 @@ public class CctvExceptionHandler {
 
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
+                .body(exception.getErrorResponseDto());
+    }
+
+    @ExceptionHandler({UnavailableStoreException.class})
+    public ResponseEntity<ErrorResponseDto> handleUnavailableStoreException(UnavailableStoreException exception) {
+
+        log.error("Exception [Err_Location] : {}", exception.getStackTrace().length == 0 ? exception.getClass() : exception.getStackTrace()[0]);
+        log.error("Exception [Err_Msg] : {}", exception.getErrorResponseDto());
+
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
                 .body(exception.getErrorResponseDto());
     }
 

--- a/src/main/java/com/ssg/usms/business/constant/CustomStatusCode.java
+++ b/src/main/java/com/ssg/usms/business/constant/CustomStatusCode.java
@@ -90,4 +90,8 @@ public class CustomStatusCode {
     public static final int INVALID_TIMESTAMP_FORMAT_CODE = 643;
     public static final String INVALID_TIMESTAMP_FORMAT_MESSAGE = "올바르지 못한 타입스탬프 포맷입니다.";
 
+    public static final int UNAVAILABLE_STORE_CODE = 644;
+    public static final String UNAVAILABLE_STORE_MESSAGE = "접근 불가능한 매장입니다.";
+
+
 }

--- a/src/main/java/com/ssg/usms/business/store/constant/StoreState.java
+++ b/src/main/java/com/ssg/usms/business/store/constant/StoreState.java
@@ -1,5 +1,6 @@
 package com.ssg.usms.business.store.constant;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 
 import java.util.Arrays;
@@ -14,6 +15,7 @@ public enum StoreState {
     DISAPPROVAL(2),
     STOPPED(3);
 
+    @JsonValue
     private final int code;
 
     StoreState(int code) {

--- a/src/main/java/com/ssg/usms/business/store/exception/UnavailableStoreException.java
+++ b/src/main/java/com/ssg/usms/business/store/exception/UnavailableStoreException.java
@@ -1,4 +1,13 @@
 package com.ssg.usms.business.store.exception;
 
+import com.ssg.usms.business.error.ErrorResponseDto;
+import lombok.Getter;
+
+import static com.ssg.usms.business.constant.CustomStatusCode.UNAVAILABLE_STORE_CODE;
+import static com.ssg.usms.business.constant.CustomStatusCode.UNAVAILABLE_STORE_MESSAGE;
+
+@Getter
 public class UnavailableStoreException extends RuntimeException {
+
+    private final ErrorResponseDto errorResponseDto = new ErrorResponseDto(UNAVAILABLE_STORE_CODE, UNAVAILABLE_STORE_MESSAGE);
 }

--- a/src/main/java/com/ssg/usms/business/store/service/StoreService.java
+++ b/src/main/java/com/ssg/usms/business/store/service/StoreService.java
@@ -85,6 +85,12 @@ public class StoreService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
+    public boolean isAvailable(Long storeId) {
+
+        return storeRepository.findById(storeId).getStoreState() == StoreState.APPROVAL;
+    }
+
     @Transactional
     public void update(Long storeId, String storeName, String storeAddress, String businessLicenseCode, InputStream businessLicenseImgFile) {
 

--- a/src/test/java/com/ssg/usms/business/cctv/controller/CctvControllerCreatingTest.java
+++ b/src/test/java/com/ssg/usms/business/cctv/controller/CctvControllerCreatingTest.java
@@ -33,6 +33,7 @@ import java.nio.charset.StandardCharsets;
 
 import static com.ssg.usms.business.constant.CustomStatusCode.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
@@ -69,6 +70,8 @@ public class CctvControllerCreatingTest {
         String cctvName = "cctv 명칭 1";
         HttpRequestCreatingCctvDto requestBody = new HttpRequestCreatingCctvDto();
         requestBody.setName(cctvName);
+
+        given(storeService.isAvailable(any())).willReturn(true);
 
         //when & then
         mockMvc.perform(
@@ -202,6 +205,34 @@ public class CctvControllerCreatingTest {
                 .andExpect(result -> {
                     ErrorResponseDto resultBody = objectMapper.readValue(result.getResponse().getContentAsString(StandardCharsets.UTF_8), ErrorResponseDto.class);
                     Assertions.assertThat(resultBody.getCode()).isEqualTo(NOT_OWNED_STORE_CODE);
+                })
+        ;
+    }
+
+    @DisplayName("[createCctv] : 이용 불가능한 storeId로 요청시 예외가 발생한다.")
+    @WithUserDetails("storeOwner")
+    @Test
+    public void testCreateCctvWithUnavailableStore() throws Exception {
+
+        //given
+        String cctvName = "cctv 명칭 1";
+        HttpRequestCreatingCctvDto requestBody = new HttpRequestCreatingCctvDto();
+        requestBody.setName(cctvName);
+
+        given(storeService.isAvailable(any())).willReturn(false);
+
+        //when & then
+        mockMvc.perform(
+                        MockMvcRequestBuilders
+                                .post("/api/users/{userId}/stores/{storeId}/cctvs", 1, 1)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(requestBody))
+
+                )
+                .andExpect(MockMvcResultMatchers.status().is(HttpStatus.FORBIDDEN.value()))
+                .andExpect(result -> {
+                    ErrorResponseDto resultBody = objectMapper.readValue(result.getResponse().getContentAsString(StandardCharsets.UTF_8), ErrorResponseDto.class);
+                    Assertions.assertThat(resultBody.getCode()).isEqualTo(UNAVAILABLE_STORE_CODE);
                 })
         ;
     }

--- a/src/test/java/com/ssg/usms/business/cctv/controller/CctvControllerDeletingTest.java
+++ b/src/test/java/com/ssg/usms/business/cctv/controller/CctvControllerDeletingTest.java
@@ -31,6 +31,7 @@ import java.nio.charset.StandardCharsets;
 
 import static com.ssg.usms.business.constant.CustomStatusCode.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
@@ -67,6 +68,8 @@ public class CctvControllerDeletingTest {
         Long userId = 1L;
         Long storeId = 1L;
         Long cctvId = 1L;
+
+        given(storeService.isAvailable(any())).willReturn(true);
 
         //when & then
         mockMvc.perform(
@@ -168,6 +171,33 @@ public class CctvControllerDeletingTest {
                 .andExpect(result -> {
                     ErrorResponseDto resultBody = objectMapper.readValue(result.getResponse().getContentAsString(StandardCharsets.UTF_8), ErrorResponseDto.class);
                     Assertions.assertThat(resultBody.getCode()).isEqualTo(NOT_OWNED_STORE_CODE);
+                })
+        ;
+    }
+
+    @DisplayName("[delete] : 이용 불가능한 storeId로 요청시 예외가 발생한다.")
+    @WithUserDetails("storeOwner")
+    @Test
+    public void testDeleteWithUnavailableStore() throws Exception {
+
+        //given
+        Long userId = 1L;
+        Long storeId = 1L;
+        Long cctvId = 1L;
+
+        given(storeService.isAvailable(any())).willReturn(false);
+
+        //when & then
+        mockMvc.perform(
+                        MockMvcRequestBuilders
+                                .delete("/api/users/{userId}/stores/{storeId}/cctvs/{cctvId}", userId, storeId, cctvId)
+                                .contentType(MediaType.APPLICATION_JSON)
+
+                )
+                .andExpect(MockMvcResultMatchers.status().is(HttpStatus.FORBIDDEN.value()))
+                .andExpect(result -> {
+                    ErrorResponseDto resultBody = objectMapper.readValue(result.getResponse().getContentAsString(StandardCharsets.UTF_8), ErrorResponseDto.class);
+                    Assertions.assertThat(resultBody.getCode()).isEqualTo(UNAVAILABLE_STORE_CODE);
                 })
         ;
     }

--- a/src/test/java/com/ssg/usms/business/cctv/controller/CctvControllerUpdatingTest.java
+++ b/src/test/java/com/ssg/usms/business/cctv/controller/CctvControllerUpdatingTest.java
@@ -35,6 +35,7 @@ import java.nio.charset.StandardCharsets;
 
 import static com.ssg.usms.business.constant.CustomStatusCode.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
@@ -75,6 +76,8 @@ public class CctvControllerUpdatingTest {
         String cctvName = "cctv 명칭 1";
         HttpRequestUpdatingCctvDto requestBody = new HttpRequestUpdatingCctvDto();
         requestBody.setName(cctvName);
+
+        given(storeService.isAvailable(storeId)).willReturn(true);
 
         //when & then
         mockMvc.perform(
@@ -228,6 +231,38 @@ public class CctvControllerUpdatingTest {
                 .andExpect(result -> {
                     ErrorResponseDto resultBody = objectMapper.readValue(result.getResponse().getContentAsString(StandardCharsets.UTF_8), ErrorResponseDto.class);
                     Assertions.assertThat(resultBody.getCode()).isEqualTo(NOT_OWNED_STORE_CODE);
+                })
+        ;
+    }
+
+    @DisplayName("[update] : 이용 불가능한 storeId로 요청시 예외가 발생한다.")
+    @WithUserDetails("storeOwner")
+    @Test
+    public void testUpdateWithUnavailableStore() throws Exception {
+
+        //given
+        Long userId = 1L;
+        Long storeId = 1L;
+        Long cctvId = 1L;
+
+        String cctvName = "cctv 명칭 1";
+        HttpRequestUpdatingCctvDto requestBody = new HttpRequestUpdatingCctvDto();
+        requestBody.setName(cctvName);
+
+        given(storeService.isAvailable(storeId)).willReturn(false);
+
+        //when & then
+        mockMvc.perform(
+                        MockMvcRequestBuilders
+                                .patch("/api/users/{userId}/stores/{storeId}/cctvs/{cctvId}", userId, storeId, cctvId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(requestBody))
+
+                )
+                .andExpect(MockMvcResultMatchers.status().is(HttpStatus.FORBIDDEN.value()))
+                .andExpect(result -> {
+                    ErrorResponseDto resultBody = objectMapper.readValue(result.getResponse().getContentAsString(StandardCharsets.UTF_8), ErrorResponseDto.class);
+                    Assertions.assertThat(resultBody.getCode()).isEqualTo(UNAVAILABLE_STORE_CODE);
                 })
         ;
     }


### PR DESCRIPTION
CCTV에 접근할 때 해당 매장이 승인 완료된 상태가 아니라면 접근이 불가능하게 로직 처리