### PR TITLE
[FIX] pathVariable 변수와 requestParam 변수가 겹쳐지는 문제 해결

### DIFF
--- a/src/main/java/com/ssg/usms/business/store/controller/StoreController.java
+++ b/src/main/java/com/ssg/usms/business/store/controller/StoreController.java
@@ -82,7 +82,7 @@ public class StoreController {
         }
 
         if (authorities.get(0).getAuthority().equals(ROLE_ADMIN.name())) {
-            return storeService.findAll(requestParam.getUserId(),
+            return storeService.findAll(requestParam.getUser(),
                     requestParam.getBusinessLicenseCode(),
                     requestParam.getStoreState(),
                     requestParam.getOffset(),

--- a/src/main/java/com/ssg/usms/business/store/dto/HttpRequestRetrievingStoreDto.java
+++ b/src/main/java/com/ssg/usms/business/store/dto/HttpRequestRetrievingStoreDto.java
@@ -18,7 +18,7 @@ import static com.ssg.usms.business.store.constant.StoreConstants.BUSINESS_LICEN
 @AllArgsConstructor
 public class HttpRequestRetrievingStoreDto {
 
-    private Long userId;
+    private Long user;
 
     private StoreState storeState;
 

--- a/src/test/java/com/ssg/usms/business/store/StoreTestSetup.java
+++ b/src/test/java/com/ssg/usms/business/store/StoreTestSetup.java
@@ -14,7 +14,7 @@ public class StoreTestSetup {
                 Arguments.of(
                         HttpRequestRetrievingStoreDto
                                 .builder()
-                                .userId(1L)
+                                .user(1L)
                                 .offset(1)
                                 .size(5)
                                 .build()
@@ -22,7 +22,7 @@ public class StoreTestSetup {
                 Arguments.of(
                         HttpRequestRetrievingStoreDto
                                 .builder()
-                                .userId(1L)
+                                .user(1L)
                                 .storeState(StoreState.APPROVAL)
                                 .offset(1)
                                 .size(5)
@@ -31,7 +31,7 @@ public class StoreTestSetup {
                 Arguments.of(
                         HttpRequestRetrievingStoreDto
                                 .builder()
-                                .userId(1L)
+                                .user(1L)
                                 .storeState(StoreState.APPROVAL)
                                 .businessLicenseCode("123-45-67890")
                                 .offset(0)
@@ -50,7 +50,7 @@ public class StoreTestSetup {
                 Arguments.of(
                         HttpRequestRetrievingStoreDto
                                 .builder()
-                                .userId(2L)
+                                .user(2L)
                                 .businessLicenseCode("123-45-67890")
                                 .offset(0)
                                 .size(5)

--- a/src/test/java/com/ssg/usms/business/store/controller/StoreControllerRetrievingTest.java
+++ b/src/test/java/com/ssg/usms/business/store/controller/StoreControllerRetrievingTest.java
@@ -278,7 +278,7 @@ public class StoreControllerRetrievingTest {
         stores.add(store2);
         stores.add(store3);
 
-        given(storeService.findAll(any(), isNull(), any(), anyInt(), anyInt()))
+        given(storeService.findAll(isNull(), isNull(), any(), anyInt(), anyInt()))
                 .willReturn(stores);
 
         //when & then
@@ -286,7 +286,6 @@ public class StoreControllerRetrievingTest {
                         MockMvcRequestBuilders
                                 .get("/api/users/{userId}/stores", userId)
                                 .param("storeState", "2")
-                                .param("userId", Long.toString(userId))
                                 .param("offset", Integer.toString(offset))
                                 .param("size", Integer.toString(size))
                 )
@@ -301,7 +300,7 @@ public class StoreControllerRetrievingTest {
                 })
         ;
 
-        verify(storeService, times(1)).findAll(any(), isNull(), any(), anyInt(), anyInt());
+        verify(storeService, times(1)).findAll(isNull(), isNull(), any(), anyInt(), anyInt());
         verify(storeService, times(0)).findAllByUserId(any(), anyInt(), anyInt());
 
     }

--- a/src/test/java/com/ssg/usms/business/store/repository/StoreRepositoryTest.java
+++ b/src/test/java/com/ssg/usms/business/store/repository/StoreRepositoryTest.java
@@ -59,7 +59,7 @@ public class StoreRepositoryTest {
         //given
 
         //when
-        List<Store> stores = storeRepository.findAll(requestParam.getUserId(),
+        List<Store> stores = storeRepository.findAll(requestParam.getUser(),
                                                     requestParam.getBusinessLicenseCode(),
                                                     requestParam.getStoreState(),
                                                     requestParam.getOffset(),
@@ -68,8 +68,8 @@ public class StoreRepositoryTest {
         //then
         assertThat(stores.size()).isLessThanOrEqualTo(requestParam.getSize());
         for(Store store : stores) {
-            if(requestParam.getUserId() != null) {
-                assertThat(store.getUserId()).isEqualTo(requestParam.getUserId());
+            if(requestParam.getUser() != null) {
+                assertThat(store.getUserId()).isEqualTo(requestParam.getUser());
             }
             if(requestParam.getBusinessLicenseCode() != null) {
                 assertThat(store.getBusinessLicenseCode()).isEqualTo(requestParam.getBusinessLicenseCode());


### PR DESCRIPTION
기존 PathVariable의 userId와 modelAttribute로 받은 userId가 서로 겹치면서 파라미터로 userId를 전송하지 않아도 userId 값이 세팅되어 이상 현상이 발생한 문제를 해결함