### PR TITLE
[ADD] 지역별 재난 문자 생성하는 기능 추가

### DIFF
--- a/src/main/java/com/ssg/usms/business/BusinessApplication.java
+++ b/src/main/java/com/ssg/usms/business/BusinessApplication.java
@@ -2,7 +2,9 @@ package com.ssg.usms.business;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class BusinessApplication {
 

--- a/src/main/java/com/ssg/usms/business/accident/dto/AccidentRegionDto.java
+++ b/src/main/java/com/ssg/usms/business/accident/dto/AccidentRegionDto.java
@@ -1,0 +1,17 @@
+package com.ssg.usms.business.accident.dto;
+
+import com.ssg.usms.business.accident.constant.AccidentBehavior;
+import lombok.*;
+
+@ToString
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccidentRegionDto {
+
+    private Long accidentId;
+    private String storeAddress;
+    private AccidentBehavior behavior;
+}

--- a/src/main/java/com/ssg/usms/business/accident/repository/AccidentRepository.java
+++ b/src/main/java/com/ssg/usms/business/accident/repository/AccidentRepository.java
@@ -1,6 +1,7 @@
 package com.ssg.usms.business.accident.repository;
 
 import com.ssg.usms.business.accident.constant.AccidentBehavior;
+import com.ssg.usms.business.accident.dto.AccidentRegionDto;
 import com.ssg.usms.business.accident.dto.AccidentStatDto;
 
 import java.util.List;
@@ -16,4 +17,6 @@ public interface AccidentRepository {
     List<Accident> findAllByStoreId(long storeId, long startTimestamp, long endTimestamp, int offset, int size);
 
     List<Accident> findAllByStoreId(long storeId, List<AccidentBehavior> behavior, long startTimestamp, long endTimestamp, int offset, int size);
+
+    List<AccidentRegionDto> findAccidentRegion(long startTimestamp, long endTimestamp, int offset, int size);
 }

--- a/src/main/java/com/ssg/usms/business/accident/repository/JpaAccidentRepository.java
+++ b/src/main/java/com/ssg/usms/business/accident/repository/JpaAccidentRepository.java
@@ -1,6 +1,7 @@
 package com.ssg.usms.business.accident.repository;
 
 import com.ssg.usms.business.accident.constant.AccidentBehavior;
+import com.ssg.usms.business.accident.dto.AccidentRegionDto;
 import com.ssg.usms.business.accident.dto.AccidentStatDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -35,6 +36,7 @@ public class JpaAccidentRepository implements AccidentRepository {
 
     @Override
     public List<Accident> findAllByStoreId(long storeId, long startTimestamp, long endTimestamp, int offset, int size) {
+
         return springDataJpaAccidentRepository
                 .findAllByStoreId(storeId, startTimestamp, endTimestamp, offset, size);
     }
@@ -47,4 +49,12 @@ public class JpaAccidentRepository implements AccidentRepository {
         return springDataJpaAccidentRepository
                 .findAllByStoreId(storeId, behaviorCodes, startTimestamp, endTimestamp, offset, size);
     }
+
+    @Override
+    public List<AccidentRegionDto> findAccidentRegion(long startTimestamp, long endTimestamp, int offset, int size) {
+
+        return springDataJpaAccidentRepository.getAccidentRegion(startTimestamp, endTimestamp, offset, size);
+    }
+
+
 }

--- a/src/main/java/com/ssg/usms/business/store/repository/JpaStoreRepository.java
+++ b/src/main/java/com/ssg/usms/business/store/repository/JpaStoreRepository.java
@@ -50,6 +50,12 @@ public class JpaStoreRepository implements StoreRepository {
     }
 
     @Override
+    public List<Store> findByRegion(String region) {
+
+        return springDataJpaStoreRepository.findByStoreAddressLike(region);
+    }
+
+    @Override
     public void update(Store store) {
 
     }

--- a/src/main/java/com/ssg/usms/business/store/repository/SpringDataJpaStoreRepository.java
+++ b/src/main/java/com/ssg/usms/business/store/repository/SpringDataJpaStoreRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface SpringDataJpaStoreRepository extends JpaRepository<Store, Long>, JpaSpecificationExecutor<Store> {
 
     List<Store> findByUserId(Long userId, Pageable Pageable);
+
+    List<Store> findByStoreAddressLike(String region);
 }

--- a/src/main/java/com/ssg/usms/business/store/repository/StoreRepository.java
+++ b/src/main/java/com/ssg/usms/business/store/repository/StoreRepository.java
@@ -14,9 +14,10 @@ public interface StoreRepository {
 
     List<Store> findByUserId(Long userId, int offset, int size);
 
+    List<Store> findByRegion(String region);
+
     void update(Store store);
 
     void delete(Store store);
-
 
 }

--- a/src/main/java/com/ssg/usms/business/warning/RegionWarningConstant.java
+++ b/src/main/java/com/ssg/usms/business/warning/RegionWarningConstant.java
@@ -1,0 +1,10 @@
+package com.ssg.usms.business.warning;
+
+public class RegionWarningConstant {
+
+    public static final Long MIN_REGION_WARNING_COUNT = 20L;
+
+    public static final String REGION_WARNING_SUBJECT = "[지역 재난 알림]";
+
+    public static final String REGION_WARNING_MESSAGE = "%s 지역에서 이상 행동 %s 가 %s 회 발생했습니다. 주의하시기 바랍니다.";
+}

--- a/src/main/java/com/ssg/usms/business/warning/dto/RegionWarningDto.java
+++ b/src/main/java/com/ssg/usms/business/warning/dto/RegionWarningDto.java
@@ -16,7 +16,7 @@ public class RegionWarningDto {
     private Long id;
     private String region;
     private AccidentBehavior behavior;
-    private int count;
+    private long count;
     private LocalDate date;
 
     public RegionWarningDto(RegionWarning regionWarning) {

--- a/src/main/java/com/ssg/usms/business/warning/repository/JpaRegionWarningRepository.java
+++ b/src/main/java/com/ssg/usms/business/warning/repository/JpaRegionWarningRepository.java
@@ -26,4 +26,13 @@ public class JpaRegionWarningRepository implements RegionWarningRepository {
                 Date.valueOf(endDate),
                 PageRequest.of(offset, size));
     }
+
+    @Override
+    public List<RegionWarning> findAll(String startDate, String endDate, int offset, int size) {
+
+        return springDataJpaRepository.findByDateBetween(
+                Date.valueOf(startDate),
+                Date.valueOf(endDate),
+                PageRequest.of(offset, size));
+    }
 }

--- a/src/main/java/com/ssg/usms/business/warning/repository/RegionWarning.java
+++ b/src/main/java/com/ssg/usms/business/warning/repository/RegionWarning.java
@@ -28,7 +28,7 @@ public class RegionWarning {
     private AccidentBehavior behavior;
 
     @Column(name = "occurrence_count")
-    private int count;
+    private long count;
 
     @Column(name = "occurrence_date")
     private Date date;

--- a/src/main/java/com/ssg/usms/business/warning/repository/RegionWarningRepository.java
+++ b/src/main/java/com/ssg/usms/business/warning/repository/RegionWarningRepository.java
@@ -8,4 +8,6 @@ public interface RegionWarningRepository {
 
     List<RegionWarning> findByRegion(String region, String startDate, String endDate, int offset, int size);
 
+    List<RegionWarning> findAll(String startDate, String endDate, int offset, int size);
+
 }

--- a/src/main/java/com/ssg/usms/business/warning/repository/SpringDataJpaRegionWarningRepository.java
+++ b/src/main/java/com/ssg/usms/business/warning/repository/SpringDataJpaRegionWarningRepository.java
@@ -1,5 +1,6 @@
 package com.ssg.usms.business.warning.repository;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,4 +12,5 @@ public interface SpringDataJpaRegionWarningRepository extends JpaRepository<Regi
 
     List<RegionWarning> findByRegionAndDateBetween(String region, Date startDate, Date endDate, Pageable pageable);
 
+    List<RegionWarning> findByDateBetween(Date startDate, Date endDate, PageRequest of);
 }

--- a/src/main/java/com/ssg/usms/business/warning/service/RegionWarningService.java
+++ b/src/main/java/com/ssg/usms/business/warning/service/RegionWarningService.java
@@ -1,22 +1,39 @@
 package com.ssg.usms.business.warning.service;
 
+import com.ssg.usms.business.accident.constant.AccidentBehavior;
+import com.ssg.usms.business.accident.dto.AccidentRegionDto;
+import com.ssg.usms.business.accident.repository.AccidentRepository;
+import com.ssg.usms.business.device.repository.DeviceRepository;
+import com.ssg.usms.business.device.repository.UsmsDevice;
+import com.ssg.usms.business.notification.service.NotificationService;
 import com.ssg.usms.business.store.repository.Store;
 import com.ssg.usms.business.store.repository.StoreRepository;
 import com.ssg.usms.business.warning.dto.RegionWarningDto;
+import com.ssg.usms.business.warning.repository.RegionWarning;
 import com.ssg.usms.business.warning.repository.RegionWarningRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
+import java.sql.Date;
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+
+import static com.ssg.usms.business.warning.RegionWarningConstant.*;
 
 @Service
 @RequiredArgsConstructor
 public class RegionWarningService {
 
+    private final NotificationService firebaseNotificationService;
+    private final DeviceRepository deviceRepository;
     private final StoreRepository storeRepository;
+    private final AccidentRepository accidentRepository;
     private final RegionWarningRepository regionWarningRepository;
 
     @Transactional(readOnly = true)
@@ -40,5 +57,86 @@ public class RegionWarningService {
     }
 
 
+    @Transactional
+    @Scheduled(cron = "${usms.schedule.createRegionWarning.cron}", zone = "${usms.schedule.timeZone}")
+    public void createRegionWarning() {
 
+        long endTimestamp = System.currentTimeMillis();
+        long startTimestamp = endTimestamp - 1000*60*60*24;
+
+        int offset = 0;
+        int size = 100;
+
+        Map<String, Long> regionBehaviorMap = new HashMap<>();
+
+        while(true) {
+            List<AccidentRegionDto> accidentRegionDtos = accidentRepository.findAccidentRegion(startTimestamp, endTimestamp, offset, size);
+            for(AccidentRegionDto accidentRegion : accidentRegionDtos) {
+                String key = accidentRegion.getBehavior().getCode() + " "
+                        + accidentRegion.getStoreAddress().split(" ")[0] + " "
+                        + accidentRegion.getStoreAddress().split(" ")[1];
+
+                regionBehaviorMap.put(key, regionBehaviorMap.getOrDefault(key, 0L) + 1);
+            }
+
+            if(accidentRegionDtos.size() != size) {
+                break;
+            }
+            offset += size;
+        }
+
+        regionBehaviorMap.forEach((key, value) -> {
+
+            if(value > MIN_REGION_WARNING_COUNT) {
+                String[] keyChunk = key.split(" ");
+
+                RegionWarning regionWarning = new RegionWarning();
+                regionWarning.setBehavior(AccidentBehavior.valueOfCode(Integer.parseInt(keyChunk[0])));
+                regionWarning.setRegion(keyChunk[1] + " " + keyChunk[2]);
+                regionWarning.setCount(value);
+                regionWarning.setDate(Date.valueOf(LocalDate.now().minusDays(1)));
+
+                regionWarningRepository.save(regionWarning);
+            }
+        });
+    }
+
+    @Scheduled(cron = "${usms.schedule.sendRegionWarningNotification.cron}", zone = "${usms.schedule.timeZone}")
+    public void sendRegionWarningNotification() throws IOException {
+
+        int offset = 0;
+        int size = 100;
+
+        while (true) {
+            List<RegionWarning> regionWarnings = regionWarningRepository
+                    .findAll(LocalDate.now().minusDays(1).toString(), LocalDate.now().toString(), offset, size);
+
+            for(RegionWarning regionWarning : regionWarnings) {
+                //지역을 통해 매장 찾아냄
+                String region = regionWarning.getRegion();
+                String regionLikeKeyword = region + "%";
+                List<Store> stores = storeRepository.findByRegion(regionLikeKeyword);
+
+                //매장을 소유한 유저에게 알림을 전송
+                for(Store store : stores) {
+                    Long userId = store.getUserId();
+                    List<UsmsDevice> devices = deviceRepository.findByUserId(userId);
+
+                    for(UsmsDevice device : devices) {
+                        firebaseNotificationService.send(
+                                device.getToken(),
+                                REGION_WARNING_SUBJECT,
+                                String.format(REGION_WARNING_MESSAGE, region, regionWarning.getBehavior(), regionWarning.getCount())
+                        );
+                    }
+                }
+            }
+
+            if(regionWarnings.size() != size) {
+                break;
+            }
+            offset++;
+        }
+
+    }
 }

--- a/src/test/java/com/ssg/usms/business/accident/repository/AccidentRepositoryTest.java
+++ b/src/test/java/com/ssg/usms/business/accident/repository/AccidentRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.ssg.usms.business.accident.repository;
 
 import com.ssg.usms.business.accident.constant.AccidentBehavior;
+import com.ssg.usms.business.accident.dto.AccidentRegionDto;
 import com.ssg.usms.business.accident.dto.AccidentStatDto;
 import com.ssg.usms.business.config.EmbeddedRedis;
 import org.junit.jupiter.api.DisplayName;
@@ -133,5 +134,22 @@ public class AccidentRepositoryTest {
         List<Accident> result = accidentRepository.findAllByStoreId(storeId, startTimestamp, endTimestamp, offset, size);
         assertThat(result.size()).isLessThanOrEqualTo(size);
 
+    }
+
+    @DisplayName("[findAccidentRegion] : 특정 시간동안 발생한 이상행동과 해당 지역을 조회")
+    @Test
+    public void testFindAccidentRegion() {
+
+        //given
+        int offset = 0;
+        int size = 20;
+        long startTimestamp = 0;
+        long endTimestamp = System.currentTimeMillis();
+
+        //when
+        List<AccidentRegionDto> accidentRegionDtoList = accidentRepository.findAccidentRegion(startTimestamp, endTimestamp, offset, size);
+
+        //then
+        System.out.println(accidentRegionDtoList);
     }
 }

--- a/src/test/java/com/ssg/usms/business/warning/service/RegionWarningServiceTest.java
+++ b/src/test/java/com/ssg/usms/business/warning/service/RegionWarningServiceTest.java
@@ -1,6 +1,9 @@
 package com.ssg.usms.business.warning.service;
 
 
+import com.ssg.usms.business.accident.repository.AccidentRepository;
+import com.ssg.usms.business.device.repository.DeviceRepository;
+import com.ssg.usms.business.notification.service.NotificationService;
 import com.ssg.usms.business.store.constant.StoreState;
 import com.ssg.usms.business.store.exception.NotExistingStoreException;
 import com.ssg.usms.business.store.repository.Store;
@@ -30,13 +33,20 @@ public class RegionWarningServiceTest {
 
     private RegionWarningService regionWarningService;
     @Mock
+    private NotificationService notificationService;
+    @Mock
+    private DeviceRepository deviceRepository;
+    @Mock
     private StoreRepository storeRepository;
+    @Mock
+    private AccidentRepository accidentRepository;
     @Mock
     private RegionWarningRepository regionWarningRepository;
 
     @BeforeEach
     public void setup() {
-        regionWarningService = new RegionWarningService(storeRepository, regionWarningRepository);
+        regionWarningService = new RegionWarningService(notificationService, deviceRepository, storeRepository,
+                accidentRepository, regionWarningRepository);
     }
 
     @DisplayName("[findByRegion] : 특정 매장 주위의 지역에 해당하는 재난 문자를 조회한다.")
@@ -128,4 +138,6 @@ public class RegionWarningServiceTest {
         verify(regionWarningRepository, times(0)).findByRegion( any(),  any(),  any(),  anyInt(), anyInt());
 
     }
+
+
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -47,6 +47,12 @@ usms:
     url: 1234
   stream-key:
     ttl: 120
+  schedule:
+    createRegionWarning:
+      cron: 0 0 5 * * ?
+    sendRegionWarningNotification:
+      cron: 0 0 9 * * ?
+    timeZone: Asia/Seoul
 
 cloud:
   aws:

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -35,7 +35,7 @@ INSERT INTO store (id, user_id, store_name, store_address, business_license_code
 
 INSERT INTO cctv (id, store_id, cctv_name, cctv_stream_key, is_expired)
 VALUES (1, 1, '우측 상단 CCTV', '74d18bfc-14c5-46d2-a1a8-1eb627918859', false),
-       (2, 1, '우측 하단 CCTV', '74d18bfc-14c5-46d2-a1a8-1eb627918851', false),
+       (2, 2, '우측 하단 CCTV', '74d18bfc-14c5-46d2-a1a8-1eb627918851', false),
        (3, 1, '좌측 상단 CCTV', '74d18bfc-14c5-46d2-a3a8-1eb637918859', false),
        (4, 1, '좌측 하단 CCTV', '74d18bfc-14c5-46d2-a2a8-1eb727918859', false),
        (5, 1, '정면 CCTV', '74a13bfc-14c5-46d2-a1a8-1eb627918859', false);


### PR DESCRIPTION
1. 배치 처리를 통해 매일 특정 시각마다 기존 이상 행동 기록들을 지역별 통계 자료로 추출
2. 특정 횟수 이상이 발생할 경우 DB에 기록하고 해당 지역의 점주들에게 알림을 전송하는 기능