### PR TITLE
[FIX] 리플레이 영상이 조회되지 않는 버그 수정

### DIFF
--- a/src/main/java/com/ssg/usms/business/video/controller/VideoController.java
+++ b/src/main/java/com/ssg/usms/business/video/controller/VideoController.java
@@ -56,7 +56,7 @@ public class VideoController {
     @GetMapping("/video/{protocol}/replay/{streamKey}/{filename}")
     public ResponseEntity<byte[]> getReplayVideo(@PathVariable String protocol,
                                                  @PathVariable @StreamKey String streamKey,
-                                                 @PathVariable @ReplayVideoFilename String filename) {
+                                                 @PathVariable String filename) {
         validateFileFormat(protocol, filename);
 
         Long userId = ((UsmsUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getId();

--- a/src/test/java/com/ssg/usms/business/video/controller/VideoControllerReplayStreamTest.java
+++ b/src/test/java/com/ssg/usms/business/video/controller/VideoControllerReplayStreamTest.java
@@ -254,23 +254,4 @@ public class VideoControllerReplayStreamTest {
         ;
 
     }
-
-    @DisplayName("리플레이 스트리밍 비디오 요청 : 요청 파일 명이 허용된 규격('파일 이름'.'확장자 명')에 벗어난 경우 예외를 발생시킨다.")
-    @ValueSource(strings = {"test!@!.m3u8", "TEST.TT.m3u8", "test1"})
-    @ParameterizedTest
-    public void testGetReplayVideoWithNotAllowedFormOfFilename(String filename) throws Exception {
-
-        //given
-        String streamKey = UUID.randomUUID().toString();
-        String protocol = "hls";
-
-        //when & then
-        mockMvc.perform(
-                        MockMvcRequestBuilders
-                                .get("/video/{protocol}/replay/{streamKey}/{filename}", protocol, streamKey, filename)
-                )
-                .andExpect(MockMvcResultMatchers.status().is(400))
-        ;
-
-    }
 }


### PR DESCRIPTION
.ts 파일 명이 유효성 검증에서 실패해 파일을 조회하지 못하는 상황이 발생