### PR TITLE
[FIX] 관리자가 사업자등록증 사본 이미지를 조회하지 못하는 버그 수정

### DIFF
--- a/src/main/java/com/ssg/usms/business/store/constant/StoreConstants.java
+++ b/src/main/java/com/ssg/usms/business/store/constant/StoreConstants.java
@@ -8,7 +8,7 @@ public class StoreConstants {
     public static final String BUSINESS_LICENSE_CODE_REGEX = "^\\d{3}-\\d{2}-\\d{5}$";
     public static final String STORE_NAME_REGEX = "^[가-힣a-zA-Z0-9\\s]{1,20}$";
     public static final String STORE_ADDRESS_REGEX = "^[가-힣a-zA-Z0-9\\s\\(\\)\\-]{1,50}$";
-    public static final String BUSINESS_LICENSE_IMG_KEY_REGEX = UUID_REGEX;
+    public static final String BUSINESS_LICENSE_IMG_KEY_REGEX = "^[0-9a-fA-F]{8}[0-9a-fA-F]{4}4[0-9a-fA-F]{3}[89abAB][0-9a-fA-F]{3}[0-9a-fA-F]{12}$";
 
     public static final Set<String> ALLOWED_IMG_FILE_FORMATS = Set.of("pdf", "jpg", "jpeg", "png");
 

--- a/src/main/java/com/ssg/usms/business/store/controller/StoreController.java
+++ b/src/main/java/com/ssg/usms/business/store/controller/StoreController.java
@@ -110,9 +110,19 @@ public class StoreController {
                                              @PathVariable Long storeId,
                                              @PathVariable @BusinessLicenseImgKey String licenseKey) {
 
-        userId = ((UsmsUserDetails)SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getId();
+        UsmsUserDetails userDetails = (UsmsUserDetails)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        userId = userDetails.getId();
 
-        storeService.validateOwnedStore(storeId, userId);
+        List<? extends GrantedAuthority> authorities = (List<? extends GrantedAuthority>) SecurityContextHolder.getContext()
+                .getAuthentication()
+                .getAuthorities();
+
+        if (authorities.size() != 1) {
+            throw new IllegalStateException("유저 권한 갯수가 현재 이상함");
+        }
+        if (authorities.get(0).getAuthority().equals(ROLE_STORE_OWNER.name())) {
+            storeService.validateOwnedStore(storeId, userId);
+        }
         storeService.validateOwnedBusinessLicenseImgKey(storeId, licenseKey);
 
         return storeService.findBusinessLicenseImgFile(licenseKey);

--- a/src/test/java/com/ssg/usms/business/store/controller/StoreControllerRetrievingTest.java
+++ b/src/test/java/com/ssg/usms/business/store/controller/StoreControllerRetrievingTest.java
@@ -475,7 +475,7 @@ public class StoreControllerRetrievingTest {
         //given
         Long userId = 1L;
         Long storeId = 1L;
-        String licenseKey = UUID.randomUUID().toString();
+        String licenseKey = UUID.randomUUID().toString().replace("-", "");
 
         String filePath = "beach.jpg";
         ClassPathResource resource = new ClassPathResource(filePath);
@@ -505,7 +505,7 @@ public class StoreControllerRetrievingTest {
         //given
         Long userId = 1L;
         Long storeId = 1L;
-        String licenseKey = UUID.randomUUID().toString();
+        String licenseKey = UUID.randomUUID().toString().replace("-", "");
 
         String filePath = "beach.jpg";
         ClassPathResource resource = new ClassPathResource(filePath);
@@ -535,7 +535,7 @@ public class StoreControllerRetrievingTest {
         //given
         Long userId = 1L;
         Long storeId = 1L;
-        String licenseKey = UUID.randomUUID().toString();
+        String licenseKey = UUID.randomUUID().toString().replace("-", "");
 
         String filePath = "beach.jpg";
         ClassPathResource resource = new ClassPathResource(filePath);
@@ -552,7 +552,7 @@ public class StoreControllerRetrievingTest {
 
     }
 
-    @WithUserDetails("admin")
+    @WithUserDetails("storeOwner")
     @DisplayName("[findBusinessLicenseImgFile] : 잘못된 사업자 등록증 사본 이미지 키로 요청시 예외가 발생한다.")
     @Test
     public void testFindBusinessLicenseImgFileWithInvalidLicenseKey() throws Exception {
@@ -576,7 +576,7 @@ public class StoreControllerRetrievingTest {
 
     }
 
-    @WithUserDetails("admin")
+    @WithUserDetails("storeOwner")
     @DisplayName("[findBusinessLicenseImgFile] : 존재하지 않는 매장 id로 요청시 예외가 발생한다.")
     @Test
     public void testFindBusinessLicenseImgFileWithNotExistingStore() throws Exception {
@@ -584,7 +584,7 @@ public class StoreControllerRetrievingTest {
         //given
         Long userId = 1L;
         Long storeId = 1L;
-        String licenseKey = UUID.randomUUID().toString();
+        String licenseKey = UUID.randomUUID().toString().replace("-", "");
 
         willThrow(new NotExistingStoreException()).given(storeService).validateOwnedStore(any(), any());
 
@@ -602,7 +602,7 @@ public class StoreControllerRetrievingTest {
 
     }
 
-    @WithUserDetails("admin")
+    @WithUserDetails("storeOwner")
     @DisplayName("[findBusinessLicenseImgFile] : 본인 소유가 아닌 매장 id로 요청시 예외가 발생한다.")
     @Test
     public void testFindBusinessLicenseImgFileWithNotOwnedStore() throws Exception {
@@ -610,7 +610,7 @@ public class StoreControllerRetrievingTest {
         //given
         Long userId = 1L;
         Long storeId = 1L;
-        String licenseKey = UUID.randomUUID().toString();
+        String licenseKey = UUID.randomUUID().toString().replace("-", "");
 
         willThrow(new NotOwnedStoreException()).given(storeService).validateOwnedStore(any(), any());
 
@@ -628,7 +628,7 @@ public class StoreControllerRetrievingTest {
 
     }
 
-    @WithUserDetails("admin")
+    @WithUserDetails("storeOwner")
     @DisplayName("[findBusinessLicenseImgFile] : 본인 소유가 아닌 사업자 등록증 사본 이미지 키로 요청시 예외가 발생한다.")
     @Test
     public void testFindBusinessLicenseImgFileWithNotOwnedBusinessLicenseImgKey() throws Exception {
@@ -636,7 +636,7 @@ public class StoreControllerRetrievingTest {
         //given
         Long userId = 1L;
         Long storeId = 1L;
-        String licenseKey = UUID.randomUUID().toString();
+        String licenseKey = UUID.randomUUID().toString().replace("-", "");
 
         willThrow(new NotOwnedBusinessLicenseImgIdException())
                 .given(storeService)
@@ -656,7 +656,7 @@ public class StoreControllerRetrievingTest {
 
     }
 
-    @WithUserDetails("admin")
+    @WithUserDetails("storeOwner")
     @DisplayName("[findBusinessLicenseImgFile] : 저장 과정에서 예외가 발생하는 경우")
     @Test
     public void testFindBusinessLicenseImgFileWithS3Error() throws Exception {
@@ -664,7 +664,7 @@ public class StoreControllerRetrievingTest {
         //given
         Long userId = 1L;
         Long storeId = 1L;
-        String licenseKey = UUID.randomUUID().toString();
+        String licenseKey = UUID.randomUUID().toString().replace("-", "");
 
         given(storeService.findBusinessLicenseImgFile(any())).willThrow(new AmazonClientException("예외발생"));
 


### PR DESCRIPTION
기존 코드에선 유저가 소유한 매장만 접근하게 되었는데 그러다보니 관리자가 접근하지 못하는 상황 발생